### PR TITLE
feat(ui): add dark mode with system preference detection



### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -127,4 +127,13 @@
   {% include matomo.html %}
   {% endif %}
 
+  <!-- Apply saved theme before first paint to avoid flash -->
+  <script>
+    (function() {
+      var stored = localStorage.getItem('theme');
+      var theme = stored || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  </script>
+
 </head>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -53,6 +53,11 @@
             </a>
           </li>
         {%- endfor -%}
+        <li>
+          <button id="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+            <span class="fa fa-moon-o" aria-hidden="true"></span>
+          </button>
+        </li>
       </ul>
     </div>
 

--- a/css/main.css
+++ b/css/main.css
@@ -1232,6 +1232,116 @@ td.gutter {
   border-color: #FED7D7;
 }
 
+/* --- Dark Mode --- */
+
+[data-theme="dark"] {
+  --color-bg: #0F1117;
+  --color-text: #E2E8F0;
+  --color-text-muted: #8FA3B8;
+  --color-link: #63B3ED;
+  --color-link-hover: #90CDF4;
+  --color-navbar: #0D1625;
+  --color-navbar-text: #CBD5E0;
+  --color-footer: #0D1625;
+  --color-border: #2D3748;
+  --color-card-bg: #1A2233;
+  --color-card-shadow: rgba(0, 0, 0, 0.35);
+  --color-card-shadow-hover: rgba(0, 0, 0, 0.55);
+}
+
+[data-theme="dark"] .jumbotron {
+  background-color: #1A2233;
+  border-color: #2D3748;
+}
+
+[data-theme="dark"] .skill-pill,
+[data-theme="dark"] .item-tag {
+  background-color: #1E2D42;
+  color: #A0B8D0;
+}
+
+[data-theme="dark"] .list-circles-item .item-link {
+  background-color: #1E2D42;
+  color: #CBD5E0;
+}
+
+[data-theme="dark"] .pager li a {
+  background-color: #1A2233;
+  color: #E2E8F0;
+  border-color: #2D3748;
+}
+
+[data-theme="dark"] table tr {
+  background-color: #1A2233;
+}
+
+[data-theme="dark"] table tr:nth-child(2n) {
+  background-color: #152030;
+}
+
+[data-theme="dark"] table tr th {
+  background-color: #152030;
+}
+
+[data-theme="dark"] pre.highlight,
+[data-theme="dark"] .highlight > pre,
+[data-theme="dark"] td.code pre {
+  background-color: #152030;
+  background-image: linear-gradient(#112240 50%, #152030 50%);
+}
+
+[data-theme="dark"] code table,
+[data-theme="dark"] code table td,
+[data-theme="dark"] code table th,
+[data-theme="dark"] code table tbody,
+[data-theme="dark"] code table tr,
+[data-theme="dark"] td.gutter pre {
+  background-color: #1A2233;
+}
+
+[data-theme="dark"] .blog-tags a {
+  background-color: #1E2D42;
+}
+
+[data-theme="dark"] .header-section.has-img .no-img {
+  background-color: #152030;
+}
+
+[data-theme="dark"] .box-note {
+  background-color: #1A2B3C;
+  border-color: #2C5282;
+}
+
+[data-theme="dark"] .box-warning {
+  background-color: #2D2A1A;
+  border-color: #744210;
+}
+
+[data-theme="dark"] .box-error {
+  background-color: #2D1A1A;
+  border-color: #742A2A;
+}
+
+/* Dark mode toggle button */
+#dark-mode-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-navbar-text);
+  font-size: 16px;
+  padding: 10px 12px;
+  line-height: 20px;
+  display: flex;
+  align-items: center;
+  transition: color var(--transition), opacity var(--transition);
+  opacity: 0.85;
+}
+
+#dark-mode-toggle:hover {
+  color: #fff;
+  opacity: 1;
+}
+
 /* --- Fix table border for gist snippets --- */
 
 .gist, .gist-file table tr {

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,59 @@
 // Dean Attali / Beautiful Jekyll 2016
 
+/* --- Dark Mode --- */
+(function() {
+  var STORAGE_KEY = 'theme';
+  var toggle = null;
+
+  function getSystemPref() {
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark' : 'light';
+  }
+
+  function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+    if (toggle) {
+      var icon = toggle.querySelector('.fa');
+      if (theme === 'dark') {
+        icon.classList.remove('fa-moon-o');
+        icon.classList.add('fa-sun-o');
+        toggle.setAttribute('aria-label', 'Switch to light mode');
+        toggle.setAttribute('title', 'Switch to light mode');
+      } else {
+        icon.classList.remove('fa-sun-o');
+        icon.classList.add('fa-moon-o');
+        toggle.setAttribute('aria-label', 'Switch to dark mode');
+        toggle.setAttribute('title', 'Switch to dark mode');
+      }
+    }
+  }
+
+  function initDarkMode() {
+    toggle = document.getElementById('dark-mode-toggle');
+    var stored = localStorage.getItem(STORAGE_KEY);
+    applyTheme(stored || getSystemPref());
+
+    if (toggle) {
+      toggle.addEventListener('click', function() {
+        var current = document.documentElement.getAttribute('data-theme');
+        var next = current === 'dark' ? 'light' : 'dark';
+        localStorage.setItem(STORAGE_KEY, next);
+        applyTheme(next);
+      });
+    }
+
+    if (window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {
+        if (!localStorage.getItem(STORAGE_KEY)) {
+          applyTheme(e.matches ? 'dark' : 'light');
+        }
+      });
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', initDarkMode);
+})();
+
 var main = {
 
   bigImgEl : null,


### PR DESCRIPTION
- Add CSS custom properties for dark theme under [data-theme="dark"]
- Add moon/sun toggle button to navbar
- Add JS to read/persist preference in localStorage and follow system prefers-color-scheme
- Add inline script in <head> to apply theme before first paint and prevent FOUC

https://claude.ai/code/session_01Nm3H3WSeohbcJbxpqk6B5D