### PR TITLE
docs: update README and add /test skill with install/serve/test instructions



### DIFF
--- a/.claude/commands/install.md
+++ b/.claude/commands/install.md
@@ -10,13 +10,16 @@ via Bundler using the `Gemfile` and `Gemfile.lock`.
 Run the following commands:
 
 ```bash
+# Install the pinned bundler version first (fixes CGI compatibility issue with bundler 4.x)
+gem install bundler -v 2.7.2 --no-document
+
 # Install all gem dependencies via Bundler
-bundle install
+bundle _2.7.2_ install
 ```
 
 ### Verify
 
 ```bash
-RUBYOPT="-E utf-8" bundle exec jekyll --version
+RUBYOPT="-E utf-8" PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" bundle _2.7.2_ exec jekyll --version
 # Expected: jekyll 3.x.x
 ```

--- a/.claude/commands/serve.md
+++ b/.claude/commands/serve.md
@@ -9,8 +9,8 @@ Dependencies must be installed first. Run `/install` if you haven't already.
 ## Start the server
 
 ```bash
-RUBYOPT="-E utf-8" \
-  bundle exec jekyll serve \
+RUBYOPT="-E utf-8" PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" \
+  bundle _2.7.2_ exec jekyll serve \
   --port 4000 \
   --destination /home/user/jekyll_site
 ```

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,44 @@
+# Run the Test Suite
+
+Run the Playwright E2E tests to verify all pages load correctly.
+
+## Prerequisites
+
+Dependencies must be installed first. Run `/install` if you haven't already.
+
+## Run all tests (build + test)
+
+```bash
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test
+```
+
+This builds the Jekyll site to `_site/` then runs all 40 Playwright tests.
+
+## Run tests against a running server
+
+If Jekyll is already serving on port 4000 (via `/serve`):
+
+```bash
+/opt/node22/bin/playwright test
+```
+
+## Other options
+
+```bash
+/opt/node22/bin/playwright test --headed   # show browser window
+/opt/node22/bin/playwright test --ui       # interactive UI mode
+/opt/node22/bin/playwright show-report     # view last test report
+```
+
+## What's tested
+
+- **Homepage** — hero section, skill pills, projects, avatar, nav/footer
+- **About** — loads, title, bio content
+- **Chat** — loads, H1 heading, chat status bar
+- **Snake RL** — loads, H1 heading, canvas element
+- **Language Model** — loads, H1 heading, generate button
+- **Tags** — loads, title
+- **404** — page exists
+- **Blog post** — loads, title, content
+- **Common layout** — viewport meta, nav, footer on every page
+- **RSS feed** — 200 response, valid XML, contains blog entry

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ _site
 .sass-cache
 .vagrant
 
+# playwright
+test-results/
+playwright-report/
+
 # general
 .DS_Store
 Thumbs.db

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gem "github-pages", '232', group: :jekyll_plugins
 # enable tzinfo-data for local build
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 gem 'jekyll-paginate'
+

--- a/README.md
+++ b/README.md
@@ -1,18 +1,37 @@
 # pedrohbtp.github.io
 
-This repository contains all the code for my personal website on github pages
+Personal portfolio/blog for Pedro Borges Torres, hosted on GitHub Pages. Based on [Beautiful Jekyll](https://github.com/daattali/beautiful-jekyll).
 
-Based on Beautiful Jekyll
+## Install
 
-To run locally:
-* Follow install instructions here: https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/
-* Execute: 
 ```bash
-bundle exec jekyll serve
-``` 
-# updating packages
+gem install bundler -v 2.7.2 --no-document
+bundle _2.7.2_ install
+```
 
-https://bundler.io/v1.2/man/bundle-update.1.html
+## Serve
+
 ```bash
-bundle update
+RUBYOPT="-E utf-8" PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" \
+  bundle _2.7.2_ exec jekyll serve --port 4000 --destination /home/user/jekyll_site
+```
+
+Visit http://localhost:4000. The server auto-regenerates on file changes.
+
+## Test
+
+Runs the Playwright E2E suite (40 tests) against all pages:
+
+```bash
+# Build site and run all tests (one command)
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test
+
+# Or run tests against an already-running server
+/opt/node22/bin/playwright test
+```
+
+## Update gems
+
+```bash
+bundle _2.7.2_ update
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# ---------------------------------------------------------------------------
+# Rake tasks for building and testing pedrohbtp.github.io
+#
+# Prerequisites (one-time):
+#   bundle install          — install Ruby/Jekyll dependencies
+#
+# Usage:
+#   rake build              — build the Jekyll site to _site/
+#   rake test               — build then run Playwright E2E tests
+#   rake test:e2e           — run Playwright tests (assumes server is running)
+#   rake clean              — remove the _site/ build output
+# ---------------------------------------------------------------------------
+
+SITE_DIR = '_site'
+PLAYWRIGHT = '/opt/node22/bin/playwright'
+JEKYLL_CMD = %(RUBYOPT="-E utf-8" PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" bundle _2.7.2_ exec jekyll)
+
+desc 'Build the Jekyll site to _site/'
+task :build do
+  sh "#{JEKYLL_CMD} build --destination #{SITE_DIR}"
+end
+
+namespace :test do
+  desc 'Run Playwright E2E tests (server must already be running on port 4000)'
+  task :e2e do
+    sh "#{PLAYWRIGHT} test"
+  end
+end
+
+desc 'Build the site and run all E2E tests'
+task test: :build do
+  Rake::Task['test:e2e'].invoke
+end
+
+desc 'Remove the _site/ build directory'
+task :clean do
+  rm_rf SITE_DIR
+  puts "Removed #{SITE_DIR}/"
+end
+
+task default: :test

--- a/_config.yml
+++ b/_config.yml
@@ -186,6 +186,10 @@ exclude:
   - LICENSE
   - README.md
   - Vagrantfile
+  - Rakefile
+  - package.json
+  - playwright.config.js
+  - tests/
 
 # prose.io config
 prose:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pedrohbtp-github-io",
+  "private": true,
+  "scripts": {
+    "test": "/opt/node22/bin/playwright test",
+    "test:headed": "/opt/node22/bin/playwright test --headed",
+    "test:ui": "/opt/node22/bin/playwright test --ui",
+    "test:report": "/opt/node22/bin/playwright show-report"
+  },
+  "devDependencies": {
+    "playwright": "^1.56.1"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,45 @@
+// @ts-check
+const { defineConfig, devices } = require('/opt/node22/lib/node_modules/playwright/test.js');
+
+/**
+ * Playwright configuration for pedrohbtp.github.io end-to-end tests.
+ *
+ * Prerequisites:
+ *   bundle exec jekyll serve --port 4000 --destination _site
+ *   (or: rake test  — which builds and starts the server automatically)
+ *
+ * Run tests:
+ *   /opt/node22/bin/playwright test
+ *   /opt/node22/bin/playwright test --headed   (with browser window)
+ *   /opt/node22/bin/playwright test --ui        (interactive UI mode)
+ */
+module.exports = defineConfig({
+  testDir: './tests',
+
+  /* Fail fast in CI, retry once in local dev */
+  retries: process.env.CI ? 2 : 0,
+
+  /* Collect full trace on first retry */
+  use: {
+    baseURL: 'http://localhost:4000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Start the Jekyll dev server automatically (reuse if already running) */
+  webServer: {
+    command:
+      'RUBYOPT="-E utf-8" PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" bundle _2.7.2_ exec jekyll serve --port 4000 --destination _site',
+    url: 'http://localhost:4000',
+    reuseExistingServer: true,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/tests/feed.spec.js
+++ b/tests/feed.spec.js
@@ -1,0 +1,38 @@
+// @ts-check
+const { test, expect } = require('/opt/node22/lib/node_modules/playwright/test.js');
+
+// ---------------------------------------------------------------------------
+// RSS Feed (/feed.xml)
+// ---------------------------------------------------------------------------
+test.describe('RSS Feed (/feed.xml)', () => {
+  test('responds with 200', async ({ request }) => {
+    const response = await request.get('/feed.xml');
+    expect(response.status()).toBe(200);
+  });
+
+  test('returns XML content type', async ({ request }) => {
+    const response = await request.get('/feed.xml');
+    const contentType = response.headers()['content-type'] ?? '';
+    expect(contentType).toMatch(/xml|rss|atom/i);
+  });
+
+  test('contains valid XML with feed entries', async ({ request }) => {
+    const response = await request.get('/feed.xml');
+    const body = await response.text();
+
+    // Root element is <feed> (Atom) or <rss>
+    expect(body).toMatch(/<feed|<rss/i);
+
+    // Should contain the site title
+    expect(body).toContain('Pedro Borges Torres');
+
+    // Should contain at least one entry/item (the 2015 blog post)
+    expect(body).toMatch(/<entry>|<item>/i);
+  });
+
+  test('feed entry links back to the blog post', async ({ request }) => {
+    const response = await request.get('/feed.xml');
+    const body = await response.text();
+    expect(body).toContain('first-post');
+  });
+});

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -1,0 +1,222 @@
+// @ts-check
+const { test, expect } = require('/opt/node22/lib/node_modules/playwright/test.js');
+
+// Jekyll outputs every page as a directory index (pretty URLs).
+// e.g. chat.html → /chat/   aboutme.md → /aboutme/
+//
+// Pages with `use-site-title: true` in their front matter use the site
+// description as the <title>; their page title appears in <h1> instead.
+
+// ---------------------------------------------------------------------------
+// Homepage
+// ---------------------------------------------------------------------------
+test.describe('Homepage (/)', () => {
+  test('has correct page title', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/Pedro Borges Torres/);
+  });
+
+  test('renders hero section with name and tagline', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.hero-section')).toBeVisible();
+    await expect(page.locator('.hero-name')).toContainText('Pedro Borges Torres');
+    await expect(page.locator('.hero-tagline')).toContainText('Software Engineer');
+  });
+
+  test('displays skill pills', async ({ page }) => {
+    await page.goto('/');
+    const pills = page.locator('.skill-pill');
+    await expect(pills.first()).toBeVisible();
+    await expect(pills).toHaveCount(7); // Python, PyTorch, LLMs, AWS, Cloud, Backend, Machine Learning
+  });
+
+  test('has navigation bar', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('nav')).toBeVisible();
+  });
+
+  test('has footer', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('footer')).toBeVisible();
+  });
+
+  test('shows projects section', async ({ page }) => {
+    await page.goto('/');
+    // Project items use class "item-name" for their titles
+    await expect(page.locator('.item-name').first()).toBeVisible();
+  });
+
+  test('avatar image loads', async ({ page }) => {
+    await page.goto('/');
+    const avatar = page.locator('img[src*="me.jpg"], img[src*="me.jpeg"]').first();
+    await expect(avatar).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// About Me page
+// ---------------------------------------------------------------------------
+test.describe('About Me page (/aboutme/)', () => {
+  test('loads without error', async ({ page }) => {
+    const response = await page.goto('/aboutme/');
+    expect(response?.status()).toBeLessThan(400);
+  });
+
+  test('has correct page title', async ({ page }) => {
+    await page.goto('/aboutme/');
+    await expect(page).toHaveTitle(/About me/i);
+  });
+
+  test('contains bio text', async ({ page }) => {
+    await page.goto('/aboutme/');
+    await expect(page.locator('body')).toContainText('UCLA');
+  });
+
+  test('has navigation bar', async ({ page }) => {
+    await page.goto('/aboutme/');
+    await expect(page.locator('nav')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local AI Chat page
+// ---------------------------------------------------------------------------
+test.describe('Chat page (/chat/)', () => {
+  test('loads without error', async ({ page }) => {
+    const response = await page.goto('/chat/');
+    expect(response?.status()).toBeLessThan(400);
+  });
+
+  test('has correct page heading (h1)', async ({ page }) => {
+    // use-site-title: true puts site desc in <title>; page title is in <h1>
+    await page.goto('/chat/');
+    await expect(page.locator('h1')).toContainText('Local AI Chat');
+  });
+
+  test('renders chat status bar', async ({ page }) => {
+    await page.goto('/chat/');
+    await expect(page.locator('#status-bar, .chat-status')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Snake Game AI page
+// ---------------------------------------------------------------------------
+test.describe('Snake RL page (/snake-rl/)', () => {
+  test('loads without error', async ({ page }) => {
+    const response = await page.goto('/snake-rl/');
+    expect(response?.status()).toBeLessThan(400);
+  });
+
+  test('has correct page heading (h1)', async ({ page }) => {
+    await page.goto('/snake-rl/');
+    await expect(page.locator('h1')).toContainText('Snake Game AI');
+  });
+
+  test('contains game canvas', async ({ page }) => {
+    await page.goto('/snake-rl/');
+    await expect(page.locator('canvas')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Language Model page
+// ---------------------------------------------------------------------------
+test.describe('Language Model page (/language-model/)', () => {
+  test('loads without error', async ({ page }) => {
+    const response = await page.goto('/language-model/');
+    expect(response?.status()).toBeLessThan(400);
+  });
+
+  test('has correct page heading (h1)', async ({ page }) => {
+    await page.goto('/language-model/');
+    await expect(page.locator('h1')).toContainText('Language Model');
+  });
+
+  test('contains Generate Text link', async ({ page }) => {
+    await page.goto('/language-model/');
+    // The generate action is an <a> with onclick, not a <button>
+    await expect(page.locator('a:has-text("Generate"), a.btn')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tag Index page
+// ---------------------------------------------------------------------------
+test.describe('Tags page (/tags/)', () => {
+  test('loads without error', async ({ page }) => {
+    const response = await page.goto('/tags/');
+    expect(response?.status()).toBeLessThan(400);
+  });
+
+  test('has correct page title', async ({ page }) => {
+    await page.goto('/tags/');
+    await expect(page).toHaveTitle(/Tag Index/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 404 page
+// ---------------------------------------------------------------------------
+test.describe('404 page (/404.html)', () => {
+  test('404 page exists and loads', async ({ page }) => {
+    const response = await page.goto('/404.html');
+    expect(response?.status()).toBeLessThan(500);
+  });
+
+  test('404 page has content', async ({ page }) => {
+    await page.goto('/404.html');
+    await expect(page.locator('body')).not.toBeEmpty();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blog post
+// ---------------------------------------------------------------------------
+test.describe('Blog post (/2015-01-04-first-post/)', () => {
+  test('loads without error', async ({ page }) => {
+    const response = await page.goto('/2015-01-04-first-post/');
+    expect(response?.status()).toBeLessThan(400);
+  });
+
+  test('has correct title', async ({ page }) => {
+    await page.goto('/2015-01-04-first-post/');
+    await expect(page).toHaveTitle(/First post/i);
+  });
+
+  test('shows post content', async ({ page }) => {
+    await page.goto('/2015-01-04-first-post/');
+    await expect(page.locator('body')).toContainText('first post');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Common layout checks
+// ---------------------------------------------------------------------------
+test.describe('Common layout', () => {
+  const pages = [
+    { name: 'homepage', path: '/' },
+    { name: 'about', path: '/aboutme/' },
+    { name: 'chat', path: '/chat/' },
+  ];
+
+  for (const { name, path } of pages) {
+    test(`${name}: has non-empty <title>`, async ({ page }) => {
+      await page.goto(path);
+      const title = await page.title();
+      expect(title.trim().length).toBeGreaterThan(0);
+    });
+
+    test(`${name}: has viewport meta tag`, async ({ page }) => {
+      await page.goto(path);
+      const viewport = await page.locator('meta[name="viewport"]').getAttribute('content');
+      expect(viewport).toContain('width=device-width');
+    });
+
+    test(`${name}: has navigation and footer`, async ({ page }) => {
+      await page.goto(path);
+      await expect(page.locator('nav')).toBeVisible();
+      await expect(page.locator('footer')).toBeVisible();
+    });
+  }
+});


### PR DESCRIPTION
- README.md: replace outdated bundle exec commands with correct bundler
  2.7.2 invocations and add test section
- .claude/commands/serve.md: fix bundle command to use bundle _2.7.2_
  with rbenv PATH prefix
- .claude/commands/test.md: new /test skill documenting how to build and
  run the Playwright suite

https://claude.ai/code/session_01KsfQ6o2AinFC2RPo7wzQoX