### PR TITLE
feat(demo): add in-browser image segmentation page using MobileSAM

### DIFF
--- a/image-segmentation.html
+++ b/image-segmentation.html
@@ -1,0 +1,512 @@
+---
+layout: page
+title: Image Segmentation
+subtitle: Click any object in a photo to instantly isolate it — no server, no API calls.
+use-site-title: true
+---
+
+<script src="/js/segmentation.js"></script>
+
+<style>
+  /* ── Page wrapper ── */
+  .seg-page {
+    max-width: 700px;
+    margin: 0 auto;
+  }
+
+  /* ── Card ── */
+  .seg-card {
+    background: #0F1923;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(126, 200, 227, 0.12);
+  }
+
+  /* ── Header bar ── */
+  .seg-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 20px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  }
+
+  .seg-title-block { line-height: 1.4; }
+
+  .seg-title {
+    font-size: 13px;
+    font-weight: 700;
+    color: #E2E8F0;
+    letter-spacing: 0.3px;
+  }
+
+  .seg-subtitle {
+    font-size: 11px;
+    color: #718096;
+  }
+
+  .seg-status {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    padding: 5px 12px;
+    border-radius: 999px;
+    transition: background 0.3s ease, color 0.3s ease;
+    white-space: nowrap;
+  }
+
+  .seg-status.idle {
+    background: rgba(144, 164, 190, 0.15);
+    color: #90A4BE;
+  }
+
+  .seg-status.loading {
+    background: rgba(246, 173, 85, 0.15);
+    color: #F6AD55;
+  }
+
+  .seg-status.ready {
+    background: rgba(72, 187, 120, 0.15);
+    color: #68D391;
+  }
+
+  .seg-status.processing {
+    background: rgba(126, 200, 227, 0.15);
+    color: #7EC8E3;
+  }
+
+  .seg-status.error {
+    background: rgba(252, 129, 129, 0.15);
+    color: #FC8181;
+  }
+
+  /* ── Progress bar ── */
+  .seg-progress-wrap {
+    padding: 0 20px 14px;
+    display: none;
+  }
+
+  .seg-progress-track {
+    height: 3px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 2px;
+    overflow: hidden;
+  }
+
+  .seg-progress-fill {
+    height: 100%;
+    background: #4A7FA5;
+    border-radius: 2px;
+    transition: width 0.2s ease;
+    width: 0%;
+  }
+
+  .seg-progress-label {
+    font-size: 10px;
+    color: #718096;
+    text-align: right;
+    margin-top: 4px;
+  }
+
+  /* ── Upload area ── */
+  .seg-upload-wrap {
+    padding: 24px 20px;
+  }
+
+  .seg-upload-zone {
+    border: 2px dashed rgba(74, 127, 165, 0.4);
+    border-radius: 10px;
+    padding: 40px 24px;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .seg-upload-zone:hover,
+  .seg-upload-zone.drag-over {
+    border-color: #4A7FA5;
+    background: rgba(74, 127, 165, 0.08);
+  }
+
+  .seg-upload-icon {
+    font-size: 36px;
+    margin-bottom: 10px;
+    line-height: 1;
+  }
+
+  .seg-upload-text {
+    font-size: 14px;
+    color: #CBD5E0;
+    line-height: 1.6;
+  }
+
+  .seg-upload-link {
+    color: #4A7FA5;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .seg-upload-hint {
+    font-size: 11px;
+    color: #4A5568;
+    margin-top: 6px;
+  }
+
+  /* ── Canvas area ── */
+  .seg-canvas-wrap {
+    position: relative;
+    width: 100%;
+    line-height: 0;
+    cursor: crosshair;
+    display: none;
+  }
+
+  .seg-canvas-wrap canvas {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  #mask-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+  }
+
+  /* Spinner overlay while processing */
+  .seg-spinner-overlay {
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.25);
+    pointer-events: none;
+  }
+
+  .seg-spinner-overlay.visible {
+    display: flex;
+  }
+
+  .seg-spinner {
+    width: 36px;
+    height: 36px;
+    border: 3px solid rgba(255, 255, 255, 0.15);
+    border-top-color: #7EC8E3;
+    border-radius: 50%;
+    animation: seg-spin 0.7s linear infinite;
+  }
+
+  @keyframes seg-spin {
+    to { transform: rotate(360deg); }
+  }
+
+  /* ── Instruction hint ── */
+  .seg-hint {
+    padding: 10px 20px;
+    font-size: 12px;
+    color: #4A5568;
+    text-align: center;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    display: none;
+  }
+
+  /* ── Controls ── */
+  .seg-controls {
+    display: none;
+    gap: 10px;
+    padding: 12px 16px;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    flex-wrap: wrap;
+  }
+
+  .seg-btn {
+    border: none;
+    border-radius: 8px;
+    padding: 9px 18px;
+    font-size: 12px;
+    font-weight: 600;
+    font-family: inherit;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+
+  .seg-btn-clear {
+    background: rgba(252, 129, 129, 0.12);
+    color: #FC8181;
+    border: 1px solid rgba(252, 129, 129, 0.25);
+  }
+
+  .seg-btn-clear:hover {
+    background: rgba(252, 129, 129, 0.22);
+  }
+
+  .seg-btn-change {
+    background: rgba(255, 255, 255, 0.06);
+    color: #90A4BE;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .seg-btn-change:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #CBD5E0;
+  }
+
+  /* ── Credits ── */
+  .seg-credits {
+    margin-top: 20px;
+    font-size: 13px;
+    color: #718096;
+    line-height: 1.7;
+    text-align: center;
+  }
+
+  .seg-credits a { color: #4A7FA5; }
+  .seg-credits a:hover { color: #7EC8E3; }
+
+  /* ── Responsive ── */
+  @media (max-width: 480px) {
+    .seg-upload-zone { padding: 28px 16px; }
+    .seg-btn { padding: 8px 14px; font-size: 11px; }
+  }
+</style>
+
+<div class="seg-page">
+  <div class="seg-card">
+
+    <!-- Header -->
+    <div class="seg-header">
+      <div class="seg-title-block">
+        <div class="seg-title">Segment Anything (MobileSAM)</div>
+        <div class="seg-subtitle">Upload a photo, then click any object</div>
+      </div>
+      <span class="seg-status loading" id="seg-status">Loading…</span>
+    </div>
+
+    <!-- Progress bar (shown while model downloads) -->
+    <div class="seg-progress-wrap" id="seg-progress-wrap">
+      <div class="seg-progress-track">
+        <div class="seg-progress-fill" id="seg-progress-fill"></div>
+      </div>
+      <div class="seg-progress-label" id="seg-progress-label">Downloading model weights…</div>
+    </div>
+
+    <!-- Upload zone -->
+    <div class="seg-upload-wrap" id="seg-upload-wrap">
+      <div class="seg-upload-zone" id="upload-zone">
+        <div class="seg-upload-icon">🖼️</div>
+        <div class="seg-upload-text">
+          Drop an image here or
+          <span class="seg-upload-link" id="upload-link">click to upload</span>
+        </div>
+        <div class="seg-upload-hint">JPEG · PNG · WebP — processed entirely in your browser</div>
+      </div>
+      <input type="file" id="file-input" accept="image/*" style="display:none">
+    </div>
+
+    <!-- Canvas (hidden until image loaded) -->
+    <div class="seg-canvas-wrap" id="seg-canvas-wrap">
+      <canvas id="img-canvas"></canvas>
+      <canvas id="mask-canvas"></canvas>
+      <div class="seg-spinner-overlay" id="spinner">
+        <div class="seg-spinner"></div>
+      </div>
+    </div>
+
+    <!-- Per-image hint -->
+    <div class="seg-hint" id="seg-hint">
+      Click anywhere on the image to segment an object — each click adds a new mask
+    </div>
+
+    <!-- Action buttons -->
+    <div class="seg-controls" id="seg-controls">
+      <button class="seg-btn seg-btn-clear" id="btn-clear">Clear masks</button>
+      <button class="seg-btn seg-btn-change" id="btn-change">Change image</button>
+    </div>
+
+  </div><!-- /.seg-card -->
+
+  <p class="seg-credits">
+    Powered by
+    <a href="https://huggingface.co/Xenova/mobile_sam" target="_blank" rel="noopener">MobileSAM</a>
+    running locally via
+    <a href="https://huggingface.co/docs/transformers.js" target="_blank" rel="noopener">Transformers.js</a>.
+    Model weights (~40 MB) are cached in your browser after the first load.
+  </p>
+</div><!-- /.seg-page -->
+
+<script>
+(function () {
+  'use strict';
+
+  // ── DOM refs ──────────────────────────────────────────────────────────────
+  var statusEl     = document.getElementById('seg-status');
+  var progressWrap = document.getElementById('seg-progress-wrap');
+  var progressFill = document.getElementById('seg-progress-fill');
+  var progressLbl  = document.getElementById('seg-progress-label');
+  var uploadWrap   = document.getElementById('seg-upload-wrap');
+  var uploadZone   = document.getElementById('upload-zone');
+  var uploadLink   = document.getElementById('upload-link');
+  var fileInput    = document.getElementById('file-input');
+  var canvasWrap   = document.getElementById('seg-canvas-wrap');
+  var imgCanvas    = document.getElementById('img-canvas');
+  var maskCanvas   = document.getElementById('mask-canvas');
+  var spinner      = document.getElementById('spinner');
+  var hint         = document.getElementById('seg-hint');
+  var controls     = document.getElementById('seg-controls');
+  var btnClear     = document.getElementById('btn-clear');
+  var btnChange    = document.getElementById('btn-change');
+
+  var imgCtx  = imgCanvas.getContext('2d');
+  var imgData = null;   // The loaded HTMLImageElement
+
+  // ── Status helpers ────────────────────────────────────────────────────────
+  function setStatus(type, text) {
+    statusEl.className   = 'seg-status ' + type;
+    statusEl.textContent = text;
+  }
+
+  function showProgress(pct, label) {
+    progressWrap.style.display = 'block';
+    progressFill.style.width   = pct + '%';
+    progressLbl.textContent    = label || '';
+  }
+
+  function hideProgress() {
+    progressWrap.style.display = 'none';
+  }
+
+  // ── Load model ────────────────────────────────────────────────────────────
+  initModel(function (info) {
+    if (info.status === 'progress' && info.progress !== undefined) {
+      var pct  = Math.round(info.progress);
+      var file = info.file ? info.file.split('/').pop() : 'weights';
+      showProgress(pct, 'Downloading ' + file + '… ' + pct + '%');
+      setStatus('loading', pct + '%');
+    } else if (info.status === 'initiate') {
+      setStatus('loading', 'Initialising…');
+    } else if (info.status === 'done') {
+      setStatus('loading', 'Finalising…');
+    }
+  }).then(function () {
+    hideProgress();
+    setStatus('ready', 'Ready');
+  }).catch(function (err) {
+    hideProgress();
+    setStatus('error', 'Load failed');
+    console.error('SAM model load error:', err);
+  });
+
+  // ── File upload ───────────────────────────────────────────────────────────
+  uploadZone.addEventListener('click', function () { fileInput.click(); });
+  uploadLink.addEventListener('click', function (e) { e.stopPropagation(); fileInput.click(); });
+
+  uploadZone.addEventListener('dragover', function (e) {
+    e.preventDefault();
+    uploadZone.classList.add('drag-over');
+  });
+
+  uploadZone.addEventListener('dragleave', function () {
+    uploadZone.classList.remove('drag-over');
+  });
+
+  uploadZone.addEventListener('drop', function (e) {
+    e.preventDefault();
+    uploadZone.classList.remove('drag-over');
+    var file = e.dataTransfer.files[0];
+    if (file && file.type.startsWith('image/')) loadImage(file);
+  });
+
+  fileInput.addEventListener('change', function () {
+    if (fileInput.files[0]) loadImage(fileInput.files[0]);
+    // Reset so the same file can be re-selected
+    fileInput.value = '';
+  });
+
+  function loadImage(file) {
+    var reader = new FileReader();
+    reader.onload = function (e) {
+      var img = new Image();
+      img.onload = function () {
+        imgData = img;
+        renderImage(img);
+      };
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  }
+
+  function renderImage(img) {
+    // Cap width at 1024 px for performance
+    var maxW   = 1024;
+    var scale  = img.width > maxW ? maxW / img.width : 1;
+    var w      = Math.round(img.width  * scale);
+    var h      = Math.round(img.height * scale);
+
+    imgCanvas.width   = w;
+    imgCanvas.height  = h;
+    maskCanvas.width  = w;
+    maskCanvas.height = h;
+
+    imgCtx.drawImage(img, 0, 0, w, h);
+    maskCanvas.getContext('2d').clearRect(0, 0, w, h);
+    resetMaskCount();
+
+    uploadWrap.style.display = 'none';
+    canvasWrap.style.display = 'block';
+    hint.style.display       = 'block';
+    controls.style.display   = 'flex';
+  }
+
+  // ── Canvas click → segmentation ───────────────────────────────────────────
+  imgCanvas.addEventListener('click', function (e) {
+    if (!isModelReady() || isBusy()) return;
+
+    var rect   = imgCanvas.getBoundingClientRect();
+    var scaleX = imgCanvas.width  / rect.width;
+    var scaleY = imgCanvas.height / rect.height;
+    var cx     = (e.clientX - rect.left)  * scaleX;
+    var cy     = (e.clientY - rect.top)   * scaleY;
+
+    spinner.classList.add('visible');
+    setStatus('processing', 'Segmenting…');
+
+    runSegmentation(imgCanvas, cx, cy, maskCanvas).then(function (ok) {
+      spinner.classList.remove('visible');
+      setStatus('ready', 'Ready');
+      if (!ok) console.warn('Segmentation skipped (model busy or not ready)');
+    }).catch(function (err) {
+      spinner.classList.remove('visible');
+      setStatus('error', 'Error');
+      console.error('Segmentation error:', err);
+    });
+  });
+
+  // ── Keyboard shortcut: Escape clears masks ────────────────────────────────
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') clearMasks();
+  });
+
+  // ── Buttons ───────────────────────────────────────────────────────────────
+  btnClear.addEventListener('click', clearMasks);
+
+  btnChange.addEventListener('click', function () {
+    canvasWrap.style.display = 'none';
+    hint.style.display       = 'none';
+    controls.style.display   = 'none';
+    uploadWrap.style.display = 'block';
+    imgData = null;
+  });
+
+  function clearMasks() {
+    if (!maskCanvas) return;
+    maskCanvas.getContext('2d').clearRect(0, 0, maskCanvas.width, maskCanvas.height);
+    resetMaskCount();
+  }
+
+}());
+</script>

--- a/img/sam-demo.svg
+++ b/img/sam-demo.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- Photo frame background -->
+  <rect x="8" y="12" width="84" height="64" rx="5" fill="#1a2a3a"/>
+
+  <!-- Sky gradient area -->
+  <rect x="8" y="12" width="84" height="32" rx="5" fill="#1e3a52"/>
+  <rect x="8" y="32" width="84" height="12" fill="#1e3a52"/>
+
+  <!-- Ground area -->
+  <rect x="8" y="44" width="84" height="32" rx="0" fill="#152230"/>
+  <rect x="8" y="73" width="84" height="3" rx="0" fill="#152230"/>
+
+  <!-- Rounded bottom corners for frame -->
+  <rect x="8" y="44" width="84" height="32" rx="0" fill="#152230"/>
+  <path d="M8 72 L8 76 Q8 76 13 76 L87 76 Q92 76 92 72 Z" fill="#152230"/>
+
+  <!-- Segmented object: a simple house shape with mask overlay -->
+  <!-- House body -->
+  <rect x="34" y="46" width="32" height="24" rx="1" fill="#2a4a6a"/>
+  <!-- House roof -->
+  <polygon points="30,48 50,32 70,48" fill="#2a5a7a"/>
+  <!-- Door -->
+  <rect x="45" y="58" width="10" height="12" rx="1" fill="#1a3a5a"/>
+
+  <!-- SAM mask overlay on the house (blue semi-transparent) -->
+  <rect x="34" y="46" width="32" height="24" rx="1" fill="rgba(74, 127, 200, 0.5)"/>
+  <polygon points="30,48 50,32 70,48" fill="rgba(74, 127, 200, 0.5)"/>
+
+  <!-- Mask outline / glow -->
+  <polygon points="30,48 50,32 70,48" fill="none" stroke="#7EC8E3" stroke-width="1.5" opacity="0.8"/>
+  <rect x="34" y="46" width="32" height="24" rx="1" fill="none" stroke="#7EC8E3" stroke-width="1.5" opacity="0.8"/>
+
+  <!-- Cursor / click indicator -->
+  <circle cx="50" cy="52" r="3.5" fill="none" stroke="#ffffff" stroke-width="1.5" opacity="0.9"/>
+  <line x1="50" y1="46.5" x2="50" y2="44" stroke="#ffffff" stroke-width="1.5" opacity="0.9"/>
+  <line x1="50" y1="57.5" x2="50" y2="60" stroke="#ffffff" stroke-width="1.5" opacity="0.9"/>
+  <line x1="44.5" y1="52" x2="42" y2="52" stroke="#ffffff" stroke-width="1.5" opacity="0.9"/>
+  <line x1="55.5" y1="52" x2="58" y2="52" stroke="#ffffff" stroke-width="1.5" opacity="0.9"/>
+
+  <!-- Frame border -->
+  <rect x="8" y="12" width="84" height="64" rx="5" fill="none" stroke="rgba(126,200,227,0.25)" stroke-width="1"/>
+
+  <!-- Label strip -->
+  <rect x="8" y="80" width="84" height="14" rx="3" fill="#0d1b26"/>
+  <text x="50" y="90" text-anchor="middle" font-family="sans-serif" font-size="7" font-weight="700"
+        fill="#7EC8E3" letter-spacing="1">SAM · CLICK TO SEGMENT</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -92,6 +92,25 @@ title: Pedro Borges Torres
                     </div>
                 </div>
 
+                <!-- Image Segmentation -->
+                <div class="list-circles-item">
+                    <a href="/image-segmentation">
+                        <img src="./img/sam-demo.svg" class="item-img" alt="Image segmentation demo icon">
+                    </a>
+                    <h4 class="item-name"><a href="/image-segmentation">Image Segmentation</a></h4>
+                    <div class="item-desc">Upload a photo and click any object — SAM instantly isolates it with a coloured mask, entirely in your browser.</div>
+                    <div class="item-tags">
+                        <span class="item-tag">Computer Vision</span>
+                        <span class="item-tag">Transformers.js</span>
+                        <span class="item-tag">In-Browser AI</span>
+                    </div>
+                    <div class="item-links">
+                        <a class="item-link" href="/image-segmentation" title="Live Demo">
+                            <span class="fa fa-play"></span>
+                        </a>
+                    </div>
+                </div>
+
                 <!-- Snake RL game (moved to second position) -->
                 <div class="list-circles-item">
                     <a href="/snake-rl">

--- a/js/segmentation.js
+++ b/js/segmentation.js
@@ -1,0 +1,242 @@
+/**
+ * segmentation.js
+ * In-browser Segment Anything Model (SAM) utilities.
+ *
+ * Pure helper functions are declared at the top so that Node.js / Jest can
+ * require() this file and unit-test them without loading the browser or the
+ * Transformers.js CDN.  All SAM inference code uses dynamic import() so the
+ * CDN URL is only fetched when initModel() is actually called (never during
+ * unit tests).
+ */
+
+'use strict';
+
+// ── Pure, testable utility functions ──────────────────────────────────────
+
+/**
+ * Normalise a canvas click position to the [0, 1] range.
+ * @param {number} clickX
+ * @param {number} clickY
+ * @param {number} canvasWidth
+ * @param {number} canvasHeight
+ * @returns {[number, number]}
+ */
+function normalizeCoords(clickX, clickY, canvasWidth, canvasHeight) {
+  return [clickX / canvasWidth, clickY / canvasHeight];
+}
+
+/**
+ * Return an HSLA colour string for a given mask index, cycling through
+ * a palette of distinct hues.
+ * @param {number} maskIndex
+ * @returns {string}
+ */
+function getMaskColor(maskIndex) {
+  var hues = [220, 0, 120, 40, 280];
+  var hue = hues[maskIndex % hues.length];
+  return 'hsla(' + hue + ', 80%, 55%, 0.45)';
+}
+
+/**
+ * Build the SAM processor point-prompt input dict for a single click.
+ * @param {number} normX  Normalised x in [0, 1]
+ * @param {number} normY  Normalised y in [0, 1]
+ * @returns {{ input_points: number[][][], input_labels: number[][] }}
+ */
+function buildSamInputs(normX, normY) {
+  return {
+    input_points: [[[normX, normY]]],
+    input_labels: [[1]],
+  };
+}
+
+/**
+ * Parse an HSLA string (e.g. "hsla(220, 80%, 55%, 0.45)") into {r,g,b,a}.
+ * @param {string} hsla
+ * @returns {{ r: number, g: number, b: number, a: number }}
+ */
+function parseHsla(hsla) {
+  var m = hsla.match(
+    /hsla?\(\s*(\d+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%(?:\s*,\s*([\d.]+))?\s*\)/
+  );
+  if (!m) return { r: 37, g: 99, b: 235, a: 0.45 };
+  var rgb = hslToRgb(
+    parseInt(m[1], 10) / 360,
+    parseFloat(m[2]) / 100,
+    parseFloat(m[3]) / 100
+  );
+  return { r: rgb.r, g: rgb.g, b: rgb.b, a: m[4] !== undefined ? parseFloat(m[4]) : 1 };
+}
+
+/**
+ * Convert HSL (all values 0–1) to integer RGB (0–255).
+ * @param {number} h
+ * @param {number} s
+ * @param {number} l
+ * @returns {{ r: number, g: number, b: number }}
+ */
+function hslToRgb(h, s, l) {
+  var r, g, b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    var hue2rgb = function (p, q, t) {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    var q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    var p = 2 * l - q;
+    r = hue2rgb(p, q, h + 1 / 3);
+    g = hue2rgb(p, q, h);
+    b = hue2rgb(p, q, h - 1 / 3);
+  }
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+  };
+}
+
+// ── Module-level SAM state ─────────────────────────────────────────────────
+
+var _samModel     = null;
+var _samProcessor = null;
+var _isModelReady = false;
+var _isProcessing = false;
+var _maskCount    = 0;
+
+// ── Model initialisation ───────────────────────────────────────────────────
+
+/**
+ * Load the MobileSAM model and processor (once per page load).
+ * Uses dynamic import() so the CDN URL is never fetched at module-parse time,
+ * which keeps unit tests fast and dependency-free.
+ *
+ * @param {function} onProgress  Called with {status, progress, file} objects
+ * @returns {Promise<void>}
+ */
+async function initModel(onProgress) {
+  if (_isModelReady) return;
+
+  var tf = await import(
+    'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3/dist/transformers.min.js'
+  );
+  var SamModel     = tf.SamModel;
+  var SamProcessor = tf.SamProcessor;
+  var env          = tf.env;
+
+  env.allowLocalModels = false;
+  env.useBrowserCache  = true;
+
+  var MODEL_ID = 'Xenova/mobile_sam';
+  var cb = function (info) { if (onProgress) onProgress(info); };
+
+  var results = await Promise.all([
+    SamProcessor.from_pretrained(MODEL_ID, { progress_callback: cb }),
+    SamModel.from_pretrained(MODEL_ID,      { progress_callback: cb }),
+  ]);
+  _samProcessor = results[0];
+  _samModel     = results[1];
+  _isModelReady = true;
+}
+
+/**
+ * Run SAM inference for a single click point and draw the result.
+ *
+ * @param {HTMLCanvasElement} sourceCanvas   Canvas with the user's image
+ * @param {number} clickX                   Click X in canvas-pixel coordinates
+ * @param {number} clickY                   Click Y in canvas-pixel coordinates
+ * @param {HTMLCanvasElement} overlayCanvas  Transparent canvas for mask overlays
+ * @returns {Promise<boolean>}  true if mask drawn, false if busy / not ready
+ */
+async function runSegmentation(sourceCanvas, clickX, clickY, overlayCanvas) {
+  if (!_isModelReady || _isProcessing) return false;
+
+  _isProcessing = true;
+  try {
+    var RawImage = (await import(
+      'https://cdn.jsdelivr.net/npm/@huggingface/transformers@3/dist/transformers.min.js'
+    )).RawImage;
+
+    var rawImage = await RawImage.fromURL(sourceCanvas.toDataURL());
+    var coords   = normalizeCoords(clickX, clickY, sourceCanvas.width, sourceCanvas.height);
+    var normX    = coords[0];
+    var normY    = coords[1];
+
+    var inputs       = await _samProcessor(rawImage, buildSamInputs(normX, normY));
+    var outputs      = await _samModel(inputs);
+    var pred_masks   = outputs.pred_masks;
+
+    var masks = await _samProcessor.post_process_masks(
+      pred_masks,
+      inputs.original_sizes,
+      inputs.reshaped_input_sizes
+    );
+
+    drawMaskOnCanvas(overlayCanvas, masks[0][0], _maskCount);
+    _maskCount++;
+    return true;
+  } finally {
+    _isProcessing = false;
+  }
+}
+
+/**
+ * Draw a boolean SAM mask tensor as a semi-transparent colour overlay.
+ *
+ * @param {HTMLCanvasElement} canvas
+ * @param {{ dims: number[], data: Uint8Array|boolean[] }} maskTensor  Shape [H, W]
+ * @param {number} maskIndex
+ */
+function drawMaskOnCanvas(canvas, maskTensor, maskIndex) {
+  var ctx    = canvas.getContext('2d');
+  var dims   = maskTensor.dims;
+  var h      = dims[0];
+  var w      = dims[1];
+  var rgba   = parseHsla(getMaskColor(maskIndex));
+  var imgData = ctx.createImageData(w, h);
+  var px     = imgData.data;
+  var mask   = maskTensor.data;
+  var alpha  = Math.round(rgba.a * 255);
+
+  for (var i = 0; i < h * w; i++) {
+    if (mask[i]) {
+      var idx    = i * 4;
+      px[idx]     = rgba.r;
+      px[idx + 1] = rgba.g;
+      px[idx + 2] = rgba.b;
+      px[idx + 3] = alpha;
+    }
+  }
+
+  // Composite via a temporary canvas to preserve existing overlay content.
+  var tmp    = document.createElement('canvas');
+  tmp.width  = w;
+  tmp.height = h;
+  tmp.getContext('2d').putImageData(imgData, 0, 0);
+  ctx.drawImage(tmp, 0, 0, canvas.width, canvas.height);
+}
+
+/** Reset the running mask counter (call when user clears/changes the image). */
+function resetMaskCount() { _maskCount = 0; }
+
+/** @returns {boolean} */
+function isModelReady() { return _isModelReady; }
+
+/** @returns {boolean} */
+function isBusy() { return _isProcessing; }
+
+// ── Node / Jest export hook (no-op in the browser) ────────────────────────
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    normalizeCoords,
+    getMaskColor,
+    buildSamInputs,
+    parseHsla,
+    hslToRgb,
+  };
+}

--- a/js/segmentation.test.js
+++ b/js/segmentation.test.js
@@ -1,0 +1,121 @@
+// Jest unit tests for pure helper functions in segmentation.js.
+// These run in Node and do not require a browser, a SAM model, or the CDN.
+
+const {
+  normalizeCoords,
+  getMaskColor,
+  buildSamInputs,
+  parseHsla,
+  hslToRgb,
+} = require('./segmentation.js');
+
+// ── normalizeCoords ───────────────────────────────────────────────────────
+
+test('normalizeCoords returns [0.5, 0.5] for a centre click', () => {
+  expect(normalizeCoords(256, 128, 512, 256)).toEqual([0.5, 0.5]);
+});
+
+test('normalizeCoords returns [0, 0] for a top-left click', () => {
+  expect(normalizeCoords(0, 0, 512, 256)).toEqual([0, 0]);
+});
+
+test('normalizeCoords returns [1, 1] for a bottom-right click', () => {
+  expect(normalizeCoords(512, 256, 512, 256)).toEqual([1, 1]);
+});
+
+test('normalizeCoords handles non-centre positions', () => {
+  expect(normalizeCoords(100, 50, 400, 200)).toEqual([0.25, 0.25]);
+});
+
+// ── getMaskColor ──────────────────────────────────────────────────────────
+
+test('getMaskColor returns distinct colours for adjacent indices', () => {
+  expect(getMaskColor(0)).not.toBe(getMaskColor(1));
+});
+
+test('getMaskColor cycles every 5 indices', () => {
+  expect(getMaskColor(0)).toBe(getMaskColor(5));
+  expect(getMaskColor(1)).toBe(getMaskColor(6));
+  expect(getMaskColor(4)).toBe(getMaskColor(9));
+});
+
+test('getMaskColor returns a valid HSLA string', () => {
+  const color = getMaskColor(0);
+  expect(color).toMatch(/^hsla\(\d+,\s*\d+%,\s*\d+%,\s*[\d.]+\)$/);
+});
+
+// ── buildSamInputs ────────────────────────────────────────────────────────
+
+test('buildSamInputs formats input_points correctly', () => {
+  const result = buildSamInputs(0.5, 0.3);
+  expect(result.input_points).toEqual([[[0.5, 0.3]]]);
+});
+
+test('buildSamInputs uses foreground label (1)', () => {
+  const result = buildSamInputs(0.5, 0.3);
+  expect(result.input_labels).toEqual([[1]]);
+});
+
+test('buildSamInputs works at boundary coordinates', () => {
+  expect(buildSamInputs(0, 0).input_points).toEqual([[[0, 0]]]);
+  expect(buildSamInputs(1, 1).input_points).toEqual([[[1, 1]]]);
+});
+
+// ── parseHsla ─────────────────────────────────────────────────────────────
+
+test('parseHsla extracts alpha value correctly', () => {
+  const { a } = parseHsla('hsla(0, 0%, 0%, 0.45)');
+  expect(a).toBeCloseTo(0.45);
+});
+
+test('parseHsla converts black correctly', () => {
+  const { r, g, b } = parseHsla('hsla(0, 0%, 0%, 1)');
+  expect(r).toBe(0);
+  expect(g).toBe(0);
+  expect(b).toBe(0);
+});
+
+test('parseHsla converts white correctly', () => {
+  const { r, g, b } = parseHsla('hsla(0, 0%, 100%, 1)');
+  expect(r).toBe(255);
+  expect(g).toBe(255);
+  expect(b).toBe(255);
+});
+
+test('parseHsla returns a fallback for invalid input', () => {
+  const result = parseHsla('not-a-color');
+  expect(typeof result.r).toBe('number');
+  expect(typeof result.g).toBe('number');
+  expect(typeof result.b).toBe('number');
+  expect(typeof result.a).toBe('number');
+});
+
+// ── hslToRgb ──────────────────────────────────────────────────────────────
+
+test('hslToRgb converts pure red correctly', () => {
+  const { r, g, b } = hslToRgb(0, 1, 0.5);
+  expect(r).toBe(255);
+  expect(g).toBe(0);
+  expect(b).toBe(0);
+});
+
+test('hslToRgb converts pure green correctly', () => {
+  const { r, g, b } = hslToRgb(1 / 3, 1, 0.5);
+  expect(r).toBe(0);
+  expect(g).toBe(255);
+  expect(b).toBe(0);
+});
+
+test('hslToRgb converts pure blue correctly', () => {
+  const { r, g, b } = hslToRgb(2 / 3, 1, 0.5);
+  expect(r).toBe(0);
+  expect(g).toBe(0);
+  expect(b).toBe(255);
+});
+
+test('hslToRgb handles achromatic (grey) input', () => {
+  const { r, g, b } = hslToRgb(0, 0, 0.5);
+  expect(r).toBe(128);
+  expect(g).toBe(128);
+  expect(b).toBe(128);
+});

--- a/package.json
+++ b/package.json
@@ -5,9 +5,14 @@
     "test": "/opt/node22/bin/playwright test",
     "test:headed": "/opt/node22/bin/playwright test --headed",
     "test:ui": "/opt/node22/bin/playwright test --ui",
-    "test:report": "/opt/node22/bin/playwright show-report"
+    "test:report": "/opt/node22/bin/playwright show-report",
+    "test:unit": "jest js/segmentation.test.js"
+  },
+  "jest": {
+    "testEnvironment": "node"
   },
   "devDependencies": {
+    "jest": "^29.7.0",
     "playwright": "^1.56.1"
   }
 }


### PR DESCRIPTION
- Add image-segmentation.html: drag-and-drop upload, HTML5 Canvas
  rendering, click-to-segment UX with spinner and multi-mask overlay
- Add js/segmentation.js: pure helper functions (normalizeCoords,
  getMaskColor, buildSamInputs, parseHsla, hslToRgb) plus SAM model
  management via dynamic import(); follows project's conditional
  module.exports pattern for Node testability
- Add js/segmentation.test.js: Jest unit tests covering all pure
  functions without requiring a browser or SAM model
- Add img/sam-demo.svg: project card thumbnail
- Update index.html: add Image Segmentation project card (Computer
  Vision · Transformers.js · In-Browser AI)
- Update package.json: add jest ^29.7.0 devDependency and test:unit
  script

https://claude.ai/code/session_01YNnyJpzLye4dvPPT182g25