### PR TITLE
fix(segmentation): pass pixel coords to SAM processor instead of normalised

### DIFF
--- a/js/segmentation.js
+++ b/js/segmentation.js
@@ -39,13 +39,13 @@ function getMaskColor(maskIndex) {
 
 /**
  * Build the SAM processor point-prompt input dict for a single click.
- * @param {number} normX  Normalised x in [0, 1]
- * @param {number} normY  Normalised y in [0, 1]
+ * @param {number} x  Click x in canvas-pixel coordinates
+ * @param {number} y  Click y in canvas-pixel coordinates
  * @returns {{ input_points: number[][][], input_labels: number[][] }}
  */
-function buildSamInputs(normX, normY) {
+function buildSamInputs(x, y) {
   return {
-    input_points: [[[normX, normY]]],
+    input_points: [[[x, y]]],
     input_labels: [[1]],
   };
 }
@@ -163,11 +163,8 @@ async function runSegmentation(sourceCanvas, clickX, clickY, overlayCanvas) {
     )).RawImage;
 
     var rawImage = await RawImage.fromURL(sourceCanvas.toDataURL());
-    var coords   = normalizeCoords(clickX, clickY, sourceCanvas.width, sourceCanvas.height);
-    var normX    = coords[0];
-    var normY    = coords[1];
 
-    var inputs       = await _samProcessor(rawImage, buildSamInputs(normX, normY));
+    var inputs       = await _samProcessor(rawImage, buildSamInputs(clickX, clickY));
     var outputs      = await _samModel(inputs);
     var pred_masks   = outputs.pred_masks;
 

--- a/tests/e2e/pages.spec.js
+++ b/tests/e2e/pages.spec.js
@@ -95,7 +95,7 @@ test.describe('Chat page (/chat/)', () => {
 
   test('renders chat status bar', async ({ page }) => {
     await page.goto('/chat/');
-    await expect(page.locator('#status-bar, .chat-status')).toBeVisible();
+    await expect(page.locator('#status-indicator')).toBeVisible();
   });
 });
 
@@ -115,7 +115,7 @@ test.describe('Snake RL page (/snake-rl/)', () => {
 
   test('contains game canvas', async ({ page }) => {
     await page.goto('/snake-rl/');
-    await expect(page.locator('canvas')).toBeVisible();
+    await expect(page.locator('#snake')).toBeVisible();
   });
 });
 

--- a/tests/unit/segmentation.test.js
+++ b/tests/unit/segmentation.test.js
@@ -47,18 +47,18 @@ test('getMaskColor returns a valid HSLA string', () => {
 // ── buildSamInputs ────────────────────────────────────────────────────────
 
 test('buildSamInputs formats input_points correctly', () => {
-  const result = buildSamInputs(0.5, 0.3);
-  expect(result.input_points).toEqual([[[0.5, 0.3]]]);
+  const result = buildSamInputs(320, 240);
+  expect(result.input_points).toEqual([[[320, 240]]]);
 });
 
 test('buildSamInputs uses foreground label (1)', () => {
-  const result = buildSamInputs(0.5, 0.3);
+  const result = buildSamInputs(320, 240);
   expect(result.input_labels).toEqual([[1]]);
 });
 
 test('buildSamInputs works at boundary coordinates', () => {
   expect(buildSamInputs(0, 0).input_points).toEqual([[[0, 0]]]);
-  expect(buildSamInputs(1, 1).input_points).toEqual([[[1, 1]]]);
+  expect(buildSamInputs(1024, 768).input_points).toEqual([[[1024, 768]]]);
 });
 
 // ── parseHsla ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
The SamProcessor expects input_points in original-image pixel space and
handles internal rescaling itself.  Previously, coordinates were
normalised to [0, 1] before being passed in, which mapped every click to
near the top-left corner of the model's internal grid, producing masks
that were completely detached from the clicked object.

Also fix two E2E test selector mismatches that were already failing:
- Chat status bar: #status-bar → #status-indicator
- Snake canvas: canvas (strict, matched 2) → #snake

https://claude.ai/code/session_017GcVsni8FMNAamDqdRxEnB