### PR TITLE
chore(test): simplify unit and e2e test setup

### DIFF
--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,36 +1,54 @@
 # Run the Test Suite
 
-Run the Playwright E2E tests to verify all pages load correctly.
+Run unit tests and/or Playwright E2E tests to verify the codebase.
 
 ## Prerequisites
 
 Dependencies must be installed first. Run `/install` if you haven't already.
 
-## Run all tests (build + test)
+## Unit tests (Jest) — no server needed
+
+Fast feedback, no Jekyll server required:
 
 ```bash
-PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test
+npm run test:unit
 ```
 
-This builds the Jekyll site to `_site/` then runs all 40 Playwright tests.
+Covers 19 tests across two modules:
+- **`js/snake-dqn.js`** — `oneHotState()`, `transferWeightsFromGraphModel()`
+- **`js/segmentation.js`** — `normalizeCoords()`, `getMaskColor()`, `buildSamInputs()`, `parseHsla()`, `hslToRgb()`
 
-## Run tests against a running server
-
-If Jekyll is already serving on port 4000 (via `/serve`):
+## E2E tests (Playwright) — builds site + starts server automatically
 
 ```bash
-/opt/node22/bin/playwright test
+npm test
 ```
 
-## Other options
+Runs all 40 Playwright tests. The server starts automatically via `playwright.config.js`.
+
+## All tests (unit + E2E)
 
 ```bash
-/opt/node22/bin/playwright test --headed   # show browser window
-/opt/node22/bin/playwright test --ui       # interactive UI mode
-/opt/node22/bin/playwright show-report     # view last test report
+npm run test:all
 ```
 
-## What's tested
+## Other E2E options
+
+```bash
+npm run test:headed   # show browser window while tests run
+npm run test:ui       # interactive Playwright UI mode
+npm run test:report   # view HTML report from the last run
+```
+
+## Rake equivalents
+
+```bash
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test        # build + unit + E2E (default)
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test:unit   # unit tests only
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test:e2e    # E2E only (server must be running)
+```
+
+## What's tested (E2E)
 
 - **Homepage** — hero section, skill pills, projects, avatar, nav/footer
 - **About** — loads, title, bio content

--- a/README.md
+++ b/README.md
@@ -20,14 +20,30 @@ Visit http://localhost:4000. The server auto-regenerates on file changes.
 
 ## Test
 
-Runs the Playwright E2E suite (40 tests) against all pages:
+### Unit tests (Jest) — no server required
 
 ```bash
-# Build site and run all tests (one command)
-PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test
+npm run test:unit
+```
 
-# Or run tests against an already-running server
-/opt/node22/bin/playwright test
+### E2E tests (Playwright) — builds site and starts server automatically
+
+```bash
+npm test
+```
+
+### All tests (unit + E2E)
+
+```bash
+npm run test:all
+```
+
+### Rake equivalents
+
+```bash
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test        # unit + E2E (default)
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test:unit   # unit only
+PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" rake test:e2e    # E2E only (server must be running)
 ```
 
 ## Update gems

--- a/Rakefile
+++ b/Rakefile
@@ -5,16 +5,19 @@
 #
 # Prerequisites (one-time):
 #   bundle install          — install Ruby/Jekyll dependencies
+#   npm install             — install Node/Playwright/Jest dependencies
 #
 # Usage:
 #   rake build              — build the Jekyll site to _site/
-#   rake test               — build then run Playwright E2E tests
-#   rake test:e2e           — run Playwright tests (assumes server is running)
+#   rake test               — build then run unit tests + E2E tests (default)
+#   rake test:unit          — run Jest unit tests (no server needed)
+#   rake test:e2e           — run Playwright E2E tests (assumes server is running)
 #   rake clean              — remove the _site/ build output
 # ---------------------------------------------------------------------------
 
 SITE_DIR = '_site'
-PLAYWRIGHT = '/opt/node22/bin/playwright'
+PLAYWRIGHT = 'npx playwright'
+JEST = 'npx jest'
 JEKYLL_CMD = %(RUBYOPT="-E utf-8" PATH="/opt/rbenv/versions/3.3.6/bin:$PATH" bundle _2.7.2_ exec jekyll)
 
 desc 'Build the Jekyll site to _site/'
@@ -23,14 +26,20 @@ task :build do
 end
 
 namespace :test do
+  desc 'Run Jest unit tests (no server needed)'
+  task :unit do
+    sh "#{JEST} tests/unit"
+  end
+
   desc 'Run Playwright E2E tests (server must already be running on port 4000)'
   task :e2e do
     sh "#{PLAYWRIGHT} test"
   end
 end
 
-desc 'Build the site and run all E2E tests'
+desc 'Build the site and run all tests (unit + E2E)'
 task test: :build do
+  Rake::Task['test:unit'].invoke
   Rake::Task['test:e2e'].invoke
 end
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "pedrohbtp-github-io",
   "private": true,
   "scripts": {
-    "test": "/opt/node22/bin/playwright test",
-    "test:headed": "/opt/node22/bin/playwright test --headed",
-    "test:ui": "/opt/node22/bin/playwright test --ui",
-    "test:report": "/opt/node22/bin/playwright show-report",
-    "test:unit": "jest tests/unit"
+    "test": "playwright test",
+    "test:e2e": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "test:report": "playwright show-report",
+    "test:unit": "jest tests/unit",
+    "test:all": "jest tests/unit && playwright test"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
- Remove hardcoded /opt/node22/bin/playwright paths from package.json
  and Rakefile; use portable npx/npm-resolved binaries instead
- Add test:e2e and test:all npm scripts for clarity
- Add rake test:unit task (npx jest tests/unit); default rake test now
  runs unit tests before e2e for faster feedback
- Rewrite README.md Test section to document unit, e2e, and combined
  workflows with npm run commands
- Rewrite .claude/commands/test.md (/test skill) to cover unit tests
  and remove hardcoded binary paths

https://claude.ai/code/session_015ouyGcswyBdfjUKDf4Perm