### PR TITLE
feat(index): add Writing section featuring Medium articles

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -228,6 +228,27 @@ layout: null
   display: block;
 }
 
+/* --- Article icon (Writing section) --- */
+
+.article-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  background: var(--color-border);
+  border-radius: 6px;
+  margin-bottom: 14px;
+  font-size: 22px;
+  color: var(--color-text-muted);
+  transition: background-color var(--transition), color var(--transition);
+}
+
+[data-theme="dark"] .article-icon {
+  background-color: #1E2D42;
+  color: #A0B8D0;
+}
+
 /* --- Project card tech tags --- */
 
 .item-tags {

--- a/index.html
+++ b/index.html
@@ -69,6 +69,76 @@ title: Pedro Borges Torres
 
             </div>
 
+            <!-- Writing -->
+            <h2 class="section-heading">Writing</h2>
+            <div class="list-circles">
+
+                <div class="list-circles-item">
+                    <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
+                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/ai-monte-carlo-tree-search-mcts-49607046b204" target="_blank" rel="noopener">AI: Monte Carlo Tree Search (MCTS)</a></h4>
+                    <div class="item-desc">A deep dive into MCTS — the tree-search algorithm powering AlphaGo — covering selection, expansion, simulation, and backpropagation.</div>
+                    <div class="item-tags">
+                        <span class="item-tag">AI</span>
+                        <span class="item-tag">Algorithms</span>
+                        <span class="item-tag">Game AI</span>
+                    </div>
+                    <div class="item-links">
+                        <a class="item-link" href="https://medium.com/@pedrohbtp/ai-monte-carlo-tree-search-mcts-49607046b204" target="_blank" rel="noopener" title="Read on Medium">
+                            <span class="fa fa-medium"></span>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="list-circles-item">
+                    <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
+                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/ai-openai-gym-7096516ec422" target="_blank" rel="noopener">AI: OpenAI Gym</a></h4>
+                    <div class="item-desc">An introduction to OpenAI Gym — the standard toolkit for benchmarking reinforcement learning algorithms across a variety of environments.</div>
+                    <div class="item-tags">
+                        <span class="item-tag">AI</span>
+                        <span class="item-tag">Reinforcement Learning</span>
+                        <span class="item-tag">Python</span>
+                    </div>
+                    <div class="item-links">
+                        <a class="item-link" href="https://medium.com/@pedrohbtp/ai-openai-gym-7096516ec422" target="_blank" rel="noopener" title="Read on Medium">
+                            <span class="fa fa-medium"></span>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="list-circles-item">
+                    <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
+                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/serverless-infrastructures-b2bc62b4e3af" target="_blank" rel="noopener">Serverless Infrastructures</a></h4>
+                    <div class="item-desc">Why serverless is the right model for true auto-scaling — tying infrastructure costs directly to usage rather than provisioned capacity.</div>
+                    <div class="item-tags">
+                        <span class="item-tag">AWS</span>
+                        <span class="item-tag">Serverless</span>
+                        <span class="item-tag">Cloud</span>
+                    </div>
+                    <div class="item-links">
+                        <a class="item-link" href="https://medium.com/@pedrohbtp/serverless-infrastructures-b2bc62b4e3af" target="_blank" rel="noopener" title="Read on Medium">
+                            <span class="fa fa-medium"></span>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="list-circles-item">
+                    <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
+                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/upverter-my-experience-with-designing-pcbs-38b2c70605fb" target="_blank" rel="noopener">Upverter — Designing PCBs</a></h4>
+                    <div class="item-desc">Hands-on experience with Upverter, a browser-based PCB design tool — from schematic capture to layout for a real hardware project.</div>
+                    <div class="item-tags">
+                        <span class="item-tag">Hardware</span>
+                        <span class="item-tag">PCB</span>
+                        <span class="item-tag">Engineering</span>
+                    </div>
+                    <div class="item-links">
+                        <a class="item-link" href="https://medium.com/@pedrohbtp/upverter-my-experience-with-designing-pcbs-38b2c70605fb" target="_blank" rel="noopener" title="Read on Medium">
+                            <span class="fa fa-medium"></span>
+                        </a>
+                    </div>
+                </div>
+
+            </div>
+
             <!-- Projects -->
             <h2 class="section-heading">Projects</h2>
             <div class="list-circles">


### PR DESCRIPTION
Surface all four Medium articles (@pedrohbtp) on the homepage in a
2×2 card grid between "On the Media" and "Projects". Reuses the
existing .list-circles layout with a new .article-icon helper class
(48×48 Medium icon in a pill container) instead of an image, keeping
the visual language fully consistent. Dark-mode styles included.

https://claude.ai/code/session_01MDXEs5ZxD9bjwMhSceJKzD