### PR TITLE
feat(nav): replace social icon buttons with labeled Connect dropdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,7 +76,6 @@ social-network-links:
   # email: "someone@example.com"
   # facebook: daattali
   github: pedrohbtp
-  twitter: pebtp
 #  reddit: yourname
 #  google-plus: +DeanAttali
   linkedin: pedrohbtp
@@ -94,7 +93,7 @@ social-network-links:
 
 # Select which share links to show in posts
 share-links-active:
-  twitter: true
+  twitter: false
   facebook: true
   google: false
   linkedin: true

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -16,43 +16,28 @@
 
     <div class="collapse navbar-collapse" id="main-navbar">
       <ul class="nav navbar-nav navbar-right">
-      <!-- {% for link in site.navbar-links %}
-        {% if link[1].first %}
-          <li class="navlinks-container">
-            <a class="navlinks-parent" href="javascript:void(0)">{{ link[0] }}</a>
-            <div class="navlinks-children">
-              {% for childlink in link[1] %}
-                {% for linkparts in childlink %}
-                  {% include navbarlink.html link=linkparts %}
-                {% endfor %}
-              {% endfor %}
-            </div>
-          </li>
-        {% else %}
-          <li>
-            {% include navbarlink.html link=link %}
-          </li>
-        {% endif %}
-        {% endfor %} -->
-          {%- for link in site.social-network-links -%}
-          {%- assign curkey = link[0] -%}
-          {%- assign element = site.data.SocialNetworks[curkey] -%}
-          <li>
-          {%- if curkey == 'rss' -%}
-            <a href="{{ '/feed.xml' | prepend: site.baseurl }}" title="{{ element.name }}">
-          {%- elsif curkey == 'yelp' -%}
-            <a href="https://{{ site.social-network-links[curkey] }}.yelp.com" title="{{ element.name }}">
-          {%- else -%}
-            <a href="{{element.baseURL}}{{ site.social-network-links[curkey] }}" title="{{ element.name }}">
-          {%- endif -%}
-              <span class="fa-stack fa-lg" aria-hidden="true">
-                <i class="fa fa-circle fa-stack-2x"></i>
-                <i class="fa {{ element.icon }} fa-stack-1x fa-inverse"></i>
-              </span>
-              <span class="sr-only">{{ element.name }}</span>
-            </a>
-          </li>
-        {%- endfor -%}
+        <li class="navlinks-container">
+          <a class="navlinks-parent" href="javascript:void(0)">Connect</a>
+          <div class="navlinks-children">
+            {%- for link in site.social-network-links -%}
+            {%- assign curkey = link[0] -%}
+            {%- assign element = site.data.SocialNetworks[curkey] -%}
+            {%- if curkey == 'rss' -%}
+              <a href="{{ '/feed.xml' | prepend: site.baseurl }}" title="{{ element.name }}">
+                <i class="fa {{ element.icon }}" aria-hidden="true"></i> {{ element.name }}
+              </a>
+            {%- elsif curkey == 'yelp' -%}
+              <a href="https://{{ site.social-network-links[curkey] }}.yelp.com" title="{{ element.name }}">
+                <i class="fa {{ element.icon }}" aria-hidden="true"></i> {{ element.name }}
+              </a>
+            {%- else -%}
+              <a href="{{ element.baseURL }}{{ site.social-network-links[curkey] }}" title="{{ element.name }}" target="_blank" rel="noopener noreferrer">
+                <i class="fa {{ element.icon }}" aria-hidden="true"></i> {{ element.name }}
+              </a>
+            {%- endif -%}
+            {%- endfor -%}
+          </div>
+        </li>
         <li>
           <button id="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <span class="fa fa-moon-o" aria-hidden="true"></span>

--- a/css/main.css
+++ b/css/main.css
@@ -663,13 +663,26 @@ img {
 }
 
 .navbar-custom .nav .navlinks-container .navlinks-children a {
-  display: block;
-  padding: 10px;
-  padding-left: 30px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
   background-color: {{ site.navbar-children-col }};
   text-decoration: none !important;
   border-width: 0 1px 1px 1px;
   font-weight: normal;
+  white-space: nowrap;
+  transition: background var(--transition);
+}
+
+.navbar-custom .nav .navlinks-container .navlinks-children a:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.navbar-custom .nav .navlinks-container .navlinks-children a .fa {
+  width: 16px;
+  text-align: center;
+  flex-shrink: 0;
 }
 
 @media only screen and (max-width: 767px) {
@@ -695,7 +708,7 @@ img {
     position: absolute;
   }
   .navbar-custom .nav .navlinks-container .navlinks-children a {
-    padding-left: 10px;
+    padding: 10px 18px;
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-width: 0 1px 1px;
   }


### PR DESCRIPTION
- Remove Twitter from social-network-links and share-links-active
- Replace flat icon-only buttons in navbar with a navlinks-container
  dropdown labelled "Connect" that shows each platform with its icon
  and full name, opening in a new tab
- Improve dropdown item styling: flex layout with icon alignment,
  hover highlight, and consistent padding