### PR TITLE
feat(seo): improve on-page SEO across the site



### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ baseurl: ""
 title: Pedro Borges Torres
 
 # Short description of your site
-description: Place for general information about myself and projects
+description: "Software Engineer & Entrepreneur — MS CS from UCLA, specializing in AI, LLMs, and cloud systems."
 
 # --- Navigation bar options --- #
 
@@ -66,6 +66,7 @@ footer-link-col: "#CBD5E0"
 # Important: you must keep the "name" parameter, everything else you can remove
 author:
   name: Pedro Borges Torres
+  twitter: TechWithPedro
 
 # Select your active Social Network Links.
 # Uncomment the links you want to show in the footer and add your information to each link.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -79,7 +79,7 @@
   {% endif %}
 
 
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content="{% if page.id %}article{% else %}website{% endif %}" />
 
   {% if page.id %}
   <meta property="og:url" content="{{ site.url }}{{ page.url }}" />
@@ -98,8 +98,10 @@
 
   <!-- Twitter summary cards -->
   <meta name="twitter:card" content="summary" />
+  {% if site.author.twitter %}
   <meta name="twitter:site" content="@{{ site.author.twitter }}" />
   <meta name="twitter:creator" content="@{{ site.author.twitter }}" />
+  {% endif %}
 
   {% if page.meta-title %}
   <meta name="twitter:title" content="{{ page.meta-title }}" />
@@ -126,6 +128,8 @@
   {% if site.matomo %}
   {% include matomo.html %}
   {% endif %}
+
+  {% include jsonld.html %}
 
   <!-- Apply saved theme before first paint to avoid flash -->
   <script>

--- a/_includes/jsonld.html
+++ b/_includes/jsonld.html
@@ -1,0 +1,32 @@
+{% if page.url == "/" or page.url == "/index.html" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Pedro Borges Torres",
+  "url": "{{ site.url }}",
+  "image": "{{ site.url }}{{ site.avatar }}",
+  "jobTitle": "Software Engineer & Entrepreneur",
+  "alumniOf": {"@type": "CollegeOrUniversity", "name": "UCLA"},
+  "sameAs": [
+    "https://github.com/pedrohbtp",
+    "https://www.linkedin.com/in/pedrohbtp",
+    "https://medium.com/@pedrohbtp",
+    "https://www.youtube.com/@TechWithPedro"
+  ]
+}
+</script>
+{% elsif page.id %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": "{{ page.title | escape }}",
+  "description": "{{ page.subtitle | default: page.excerpt | strip_html | escape }}",
+  "image": "{{ page.share-img | default: site.avatar | prepend: site.url }}",
+  "author": {"@type": "Person", "name": "{{ site.author.name }}"},
+  "datePublished": "{{ page.date | date_to_xmlschema }}",
+  "url": "{{ site.url }}{{ page.url }}"
+}
+</script>
+{% endif %}

--- a/aboutme.md
+++ b/aboutme.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: About me
-# subtitle: Why you'd want to go on a date with me
+subtitle: "About Pedro Borges Torres — Software Engineer & Entrepreneur with an MS in CS from UCLA, specializing in AI and cloud systems."
 ---
 
 MS CS - UCLA. BS Mechatronics Eng - UnB. 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: home
 title: Pedro Borges Torres
+subtitle: "Software Engineer & Entrepreneur. MS CS from UCLA specializing in AI, LLMs, and cloud systems. Co-founder of Dynacloud."
 ---
 
 <!-- Hero -->
@@ -75,7 +76,7 @@ title: Pedro Borges Torres
 
                 <div class="list-circles-item">
                     <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
-                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/ai-monte-carlo-tree-search-mcts-49607046b204" target="_blank" rel="noopener">AI: Monte Carlo Tree Search (MCTS)</a></h4>
+                    <h3 class="item-name"><a href="https://medium.com/@pedrohbtp/ai-monte-carlo-tree-search-mcts-49607046b204" target="_blank" rel="noopener">AI: Monte Carlo Tree Search (MCTS)</a></h3>
                     <div class="item-desc">A deep dive into MCTS — the tree-search algorithm powering AlphaGo — covering selection, expansion, simulation, and backpropagation.</div>
                     <div class="item-tags">
                         <span class="item-tag">AI</span>
@@ -91,7 +92,7 @@ title: Pedro Borges Torres
 
                 <div class="list-circles-item">
                     <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
-                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/ai-openai-gym-7096516ec422" target="_blank" rel="noopener">AI: OpenAI Gym</a></h4>
+                    <h3 class="item-name"><a href="https://medium.com/@pedrohbtp/ai-openai-gym-7096516ec422" target="_blank" rel="noopener">AI: OpenAI Gym</a></h3>
                     <div class="item-desc">An introduction to OpenAI Gym — the standard toolkit for benchmarking reinforcement learning algorithms across a variety of environments.</div>
                     <div class="item-tags">
                         <span class="item-tag">AI</span>
@@ -107,7 +108,7 @@ title: Pedro Borges Torres
 
                 <div class="list-circles-item">
                     <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
-                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/serverless-infrastructures-b2bc62b4e3af" target="_blank" rel="noopener">Serverless Infrastructures</a></h4>
+                    <h3 class="item-name"><a href="https://medium.com/@pedrohbtp/serverless-infrastructures-b2bc62b4e3af" target="_blank" rel="noopener">Serverless Infrastructures</a></h3>
                     <div class="item-desc">Why serverless is the right model for true auto-scaling — tying infrastructure costs directly to usage rather than provisioned capacity.</div>
                     <div class="item-tags">
                         <span class="item-tag">AWS</span>
@@ -123,7 +124,7 @@ title: Pedro Borges Torres
 
                 <div class="list-circles-item">
                     <div class="article-icon"><i class="fa fa-medium" aria-hidden="true"></i></div>
-                    <h4 class="item-name"><a href="https://medium.com/@pedrohbtp/upverter-my-experience-with-designing-pcbs-38b2c70605fb" target="_blank" rel="noopener">Upverter — Designing PCBs</a></h4>
+                    <h3 class="item-name"><a href="https://medium.com/@pedrohbtp/upverter-my-experience-with-designing-pcbs-38b2c70605fb" target="_blank" rel="noopener">Upverter — Designing PCBs</a></h3>
                     <div class="item-desc">Hands-on experience with Upverter, a browser-based PCB design tool — from schematic capture to layout for a real hardware project.</div>
                     <div class="item-tags">
                         <span class="item-tag">Hardware</span>
@@ -148,7 +149,7 @@ title: Pedro Borges Torres
                     <a href="/neural-net">
                         <img src="./img/neural-net-icon.svg" class="item-img" alt="Neural net demo icon">
                     </a>
-                    <h4 class="item-name"><a href="/neural-net">Train Your Own AI</a></h4>
+                    <h3 class="item-name"><a href="/neural-net">Train Your Own AI</a></h3>
                     <div class="item-desc">Place dots on a grid and watch a tiny neural net learn the decision boundary live in your browser.</div>
                     <div class="item-tags">
                         <span class="item-tag">TensorFlow.js</span>
@@ -167,7 +168,7 @@ title: Pedro Borges Torres
                     <a href="/image-segmentation">
                         <img src="./img/sam-demo.svg" class="item-img" alt="Image segmentation demo icon">
                     </a>
-                    <h4 class="item-name"><a href="/image-segmentation">Image Segmentation</a></h4>
+                    <h3 class="item-name"><a href="/image-segmentation">Image Segmentation</a></h3>
                     <div class="item-desc">Upload a photo and click any object — SAM instantly isolates it with a coloured mask, entirely in your browser.</div>
                     <div class="item-tags">
                         <span class="item-tag">Computer Vision</span>
@@ -186,7 +187,7 @@ title: Pedro Borges Torres
                     <a href="/snake-rl">
                         <img src="./img/joystick.png" class="item-img" alt="Snake game icon">
                     </a>
-                    <h4 class="item-name">snake-reinforcement-learning</h4>
+                    <h3 class="item-name">snake-reinforcement-learning</h3>
                     <div class="item-desc">Live demo of a trained RL agent playing a simplified version of the classic Snake game.</div>
                     <div class="item-tags">
                         <span class="item-tag">Reinforcement Learning</span>
@@ -204,7 +205,7 @@ title: Pedro Borges Torres
                     <a href="/chat">
                         <img src="./img/ai-chat.svg" class="item-img" alt="Local AI Chat icon">
                     </a>
-                    <h4 class="item-name">Local AI Chat</h4>
+                    <h3 class="item-name">Local AI Chat</h3>
                     <div class="item-desc">Chat with a small LLM running entirely in your browser — no server, no data sent anywhere.</div>
                     <div class="item-tags">
                         <span class="item-tag">LLMs</span>
@@ -222,7 +223,7 @@ title: Pedro Borges Torres
                     <a href="https://deduz.ai/">
                         <img src="./img/deduzai.png" class="item-img" alt="deduz.ai logo">
                     </a>
-                    <h4 class="item-name">deduz.ai</h4>
+                    <h3 class="item-name">deduz.ai</h3>
                     <div class="item-desc">AI assistant using LLMs to help answer questions about filing taxes in Brazil.</div>
                     <div class="item-tags">
                         <span class="item-tag">LLMs</span>
@@ -245,7 +246,7 @@ title: Pedro Borges Torres
                     <a href="https://github.com/pedrohbtp/pytorch-zappa-serverless">
                         <img src="./img/pytorch-logo.png" class="item-img" alt="PyTorch logo">
                     </a>
-                    <h4 class="item-name">pytorch-zappa-serverless</h4>
+                    <h3 class="item-name">pytorch-zappa-serverless</h3>
                     <div class="item-desc">Deploy a PyTorch model to AWS Lambda using Zappa — serverless ML inference.</div>
                     <div class="item-tags">
                         <span class="item-tag">PyTorch</span>
@@ -266,7 +267,7 @@ title: Pedro Borges Torres
                     <a href="https://pbandjay.io">
                         <img src="./img/pbandjay.png" class="item-img" alt="PBandJay logo">
                     </a>
-                    <h4 class="item-name">PBandJay</h4>
+                    <h3 class="item-name">PBandJay</h3>
                     <div class="item-desc">An autoservice application for restaurants and bars — streamlining ordering and payments.</div>
                     <div class="item-tags">
                         <span class="item-tag">Mobile</span>
@@ -286,7 +287,7 @@ title: Pedro Borges Torres
                     <a href="https://sababa.news/">
                         <img src="./img/iconRedAndWhite.svg" class="item-img" alt="Sababa News logo">
                     </a>
-                    <h4 class="item-name">Sababa News</h4>
+                    <h3 class="item-name">Sababa News</h3>
                     <div class="item-desc">Collaborative news platform. Built with <a href="https://github.com/israelsaba">Israel Saba</a>.</div>
                     <div class="item-tags">
                         <span class="item-tag">Collaborative</span>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://pedrohbtp.github.io/sitemap.xml


### PR DESCRIPTION
- Add keyword-rich site description to _config.yml
- Add author.twitter to enable Twitter Card meta tags
- Add subtitle to index.html and aboutme.md for meta descriptions
- Fix H2→H4 heading hierarchy skip: change all .item-name h4 to h3
- Guard twitter:site/creator tags with {% if site.author.twitter %}
- Set og:type to "article" for blog posts (was always "website")
- Create _includes/jsonld.html with Person schema (homepage) and
  BlogPosting schema (blog posts) for rich search results
- Create robots.txt pointing crawlers to sitemap.xml

https://claude.ai/code/session_015twb9L2czTZZRtCr5WKmXG