### PR TITLE
feat(nav): improve Connect dropdown and dark mode toggle

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -7,6 +7,10 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
+      <!-- Mobile-only dark mode toggle (always visible, left of hamburger) -->
+      <button class="dark-mode-toggle navbar-dark-mobile" aria-label="Toggle dark mode" title="Toggle dark mode">
+        <span class="fa fa-moon-o" aria-hidden="true"></span>
+      </button>
       {% if site.title-img %}
         <a class="navbar-brand navbar-brand-logo" href="{{ site.url }}"><img src="{{ site.title-img }}"/></a>
       {% else %}
@@ -17,7 +21,9 @@
     <div class="collapse navbar-collapse" id="main-navbar">
       <ul class="nav navbar-nav navbar-right">
         <li class="navlinks-container">
-          <a class="navlinks-parent" href="javascript:void(0)">Connect</a>
+          <a class="navlinks-parent" href="javascript:void(0)">
+            <i class="fa fa-share-alt" aria-hidden="true"></i> Connect
+          </a>
           <div class="navlinks-children">
             {%- for link in site.social-network-links -%}
             {%- assign curkey = link[0] -%}
@@ -38,8 +44,9 @@
             {%- endfor -%}
           </div>
         </li>
+        <!-- Desktop dark mode toggle (inside collapse) -->
         <li>
-          <button id="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
+          <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode" title="Toggle dark mode">
             <span class="fa fa-moon-o" aria-hidden="true"></span>
           </button>
         </li>

--- a/css/main.css
+++ b/css/main.css
@@ -652,8 +652,16 @@ img {
   position: relative;
 }
 
+.navbar-custom .nav .navlinks-parent {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .navbar-custom .nav .navlinks-parent:after {
-  content: " \25BC";
+  content: " \25BE";
+  font-size: 10px;
+  opacity: 0.7;
 }
 
 .navbar-custom .nav .navlinks-children {
@@ -669,48 +677,82 @@ img {
   padding: 10px 18px;
   background-color: {{ site.navbar-children-col }};
   text-decoration: none !important;
-  border-width: 0 1px 1px 1px;
-  font-weight: normal;
+  border-width: 0;
+  font-weight: 500;
   white-space: nowrap;
-  transition: background var(--transition);
+  transition: background var(--transition), padding-left var(--transition);
 }
 
 .navbar-custom .nav .navlinks-container .navlinks-children a:hover {
-  background-color: rgba(255, 255, 255, 0.08);
+  background-color: rgba(255, 255, 255, 0.1);
+  padding-left: 22px;
 }
 
 .navbar-custom .nav .navlinks-container .navlinks-children a .fa {
-  width: 16px;
+  width: 18px;
   text-align: center;
   flex-shrink: 0;
+  font-size: 15px;
+  opacity: 0.85;
 }
 
+/* Mobile: expand inline */
 @media only screen and (max-width: 767px) {
   .navbar-custom .nav .navlinks-container.show-children {
-    background: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 6px;
   }
   .navbar-custom .nav .navlinks-container.show-children .navlinks-children {
     display: block;
   }
+  .navbar-custom .nav .navlinks-container.show-children .navlinks-parent {
+    color: #fff;
+  }
+  .navbar-custom .nav .navlinks-container .navlinks-children a {
+    padding-left: 28px;
+    font-size: 12px;
+  }
+  .navbar-custom .nav .navlinks-container .navlinks-children a:hover {
+    padding-left: 34px;
+  }
 }
 
+/* Desktop: floating dropdown */
 @media only screen and (min-width: 768px) {
   .navbar-custom .nav .navlinks-container {
     text-align: center;
   }
   .navbar-custom .nav .navlinks-container:hover {
-    background: rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.07);
+    border-radius: 4px;
+  }
+  .navbar-custom .nav .navlinks-container:hover .navlinks-parent {
+    color: #fff;
   }
   .navbar-custom .nav .navlinks-container:hover .navlinks-children {
     display: block;
   }
   .navbar-custom .nav .navlinks-children {
     position: absolute;
+    right: 0;
+    top: 100%;
+    min-width: 190px;
+    background-color: #1a2840;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-top: none;
+    border-radius: 0 0 8px 8px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+    z-index: 1050;
   }
   .navbar-custom .nav .navlinks-container .navlinks-children a {
-    padding: 10px 18px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-width: 0 1px 1px;
+    padding: 11px 18px;
+    border: none;
+    font-size: 12px;
+    letter-spacing: 0.3px;
+  }
+  .navbar-custom .nav .navlinks-container .navlinks-children a:last-child {
+    border-radius: 0 0 8px 8px;
   }
 }
 
@@ -1356,24 +1398,45 @@ td.gutter {
   border-color: #742A2A;
 }
 
-/* Dark mode toggle button */
-#dark-mode-toggle {
-  background: none;
-  border: none;
+/* Dark mode toggle button — shared styles */
+.dark-mode-toggle {
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 20px;
   cursor: pointer;
   color: var(--color-navbar-text);
-  font-size: 16px;
-  padding: 10px 12px;
+  font-size: 14px;
+  padding: 5px 13px;
   line-height: 20px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  transition: color var(--transition), opacity var(--transition);
-  opacity: 0.85;
+  gap: 5px;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
 }
 
-#dark-mode-toggle:hover {
+.dark-mode-toggle:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.28);
   color: #fff;
-  opacity: 1;
+}
+
+/* Mobile-only dark mode toggle (in navbar-header) */
+.navbar-dark-mobile {
+  float: right;
+  margin: 9px 6px 9px 0;
+  /* visible on mobile by default */
+}
+
+/* Hide mobile toggle on desktop; both toggles share .dark-mode-toggle styles */
+@media (min-width: 768px) {
+  .navbar-dark-mobile {
+    display: none;
+  }
+}
+
+/* Desktop dark mode toggle in navbar-right li */
+#dark-mode-toggle {
+  margin: 13px 0 13px 4px;
 }
 
 /* --- Fix table border for gist snippets --- */

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,6 @@
 /* --- Dark Mode --- */
 (function() {
   var STORAGE_KEY = 'theme';
-  var toggle = null;
 
   function getSystemPref() {
     return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
@@ -12,35 +11,31 @@
 
   function applyTheme(theme) {
     document.documentElement.setAttribute('data-theme', theme);
-    if (toggle) {
-      var icon = toggle.querySelector('.fa');
-      if (theme === 'dark') {
-        icon.classList.remove('fa-moon-o');
-        icon.classList.add('fa-sun-o');
-        toggle.setAttribute('aria-label', 'Switch to light mode');
-        toggle.setAttribute('title', 'Switch to light mode');
-      } else {
-        icon.classList.remove('fa-sun-o');
-        icon.classList.add('fa-moon-o');
-        toggle.setAttribute('aria-label', 'Switch to dark mode');
-        toggle.setAttribute('title', 'Switch to dark mode');
+    var isDark = theme === 'dark';
+    var label = isDark ? 'Switch to light mode' : 'Switch to dark mode';
+    document.querySelectorAll('.dark-mode-toggle').forEach(function(btn) {
+      var icon = btn.querySelector('.fa');
+      if (icon) {
+        icon.classList.toggle('fa-sun-o', isDark);
+        icon.classList.toggle('fa-moon-o', !isDark);
       }
-    }
+      btn.setAttribute('aria-label', label);
+      btn.setAttribute('title', label);
+    });
   }
 
   function initDarkMode() {
-    toggle = document.getElementById('dark-mode-toggle');
     var stored = localStorage.getItem(STORAGE_KEY);
     applyTheme(stored || getSystemPref());
 
-    if (toggle) {
-      toggle.addEventListener('click', function() {
+    document.querySelectorAll('.dark-mode-toggle').forEach(function(btn) {
+      btn.addEventListener('click', function() {
         var current = document.documentElement.getAttribute('data-theme');
         var next = current === 'dark' ? 'light' : 'dark';
         localStorage.setItem(STORAGE_KEY, next);
         applyTheme(next);
       });
-    }
+    });
 
     if (window.matchMedia) {
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function(e) {


### PR DESCRIPTION
- Dark mode toggle: add a mobile-always-visible button in navbar-header
  (floats left of the hamburger) so users don't need to open the menu on
  mobile; desktop toggle stays in the collapsed nav-right. Both share the
  new `.dark-mode-toggle` class — JS now drives all toggles via the class
  selector instead of a single #id.
- Dark mode button: replaced bare icon with a pill-shaped button
  (subtle bg + border, hover glow) on both mobile and desktop.
- Connect dropdown: added a share icon next to the label, smaller chevron
  arrow, tighter font sizing on desktop, left-indent hover animation on
  links, rounded corners + drop-shadow on the desktop floating dropdown,
  and a highlighted bg state for the expanded mobile accordion.

https://claude.ai/code/session_01CZp2rczHXc2nDB9B4YKRHW