### PR TITLE
feat(projects): add Social Media Ideas Generator project card

### DIFF
--- a/img/social-media-ideas.svg
+++ b/img/social-media-ideas.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <rect width="48" height="48" rx="10" fill="#0F1923"/>
+  <rect x="6" y="6" width="36" height="36" rx="4" fill="#1A2A3A"/>
+  <text x="24" y="30" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SM</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -276,6 +276,26 @@ meta-description: "ML Engineer at Nirvana. MS CS from UCLA · Ex-IBM · Co-found
                 </div>
 
                 <div class="list-circles-item">
+                    <a href="https://github.com/pedrohbtp/social-media-ideas-generator">
+                        <img src="./img/social-media-ideas.svg" class="item-img" alt="Social Media Ideas Generator icon">
+                    </a>
+                    <h3 class="item-name"><a href="https://github.com/pedrohbtp/social-media-ideas-generator">Social Media Ideas Generator</a></h3>
+                    <div class="item-desc">Built an MCP server integrating Instagram and YouTube APIs with Claude, enabling AI-assisted content analysis and ideation for creator workflows. An example of agentic AI tooling built for a real production use case.</div>
+                    <div class="item-tags">
+                        <span class="item-tag">MCP</span>
+                        <span class="item-tag">Python</span>
+                        <span class="item-tag">Claude</span>
+                        <span class="item-tag">Instagram API</span>
+                        <span class="item-tag">YouTube API</span>
+                    </div>
+                    <div class="item-links">
+                        <a class="item-link" href="https://github.com/pedrohbtp/social-media-ideas-generator" title="GitHub">
+                            <span class="fa fa-github"></span>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="list-circles-item">
                     <a href="https://github.com/pedrohbtp/pytorch-zappa-serverless">
                         <img src="./img/pytorch-logo.png" class="item-img" alt="PyTorch logo">
                     </a>


### PR DESCRIPTION
Adds a new project card for the social-media-ideas-generator repo after
the AvisaAi card, including a simple SVG placeholder icon styled to match
existing icon assets.

https://claude.ai/code/session_01JyFJneH8JbPfSKKBUrogKW