### PR TITLE
docs: remove hyperlink from Dynacloud mention in hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ meta-description: "ML Engineer at Nirvana. MS CS from UCLA · Ex-IBM · Co-found
 <section class="hero-section">
     <div class="hero-inner">
         <h1 class="hero-name">Pedro Borges Torres</h1>
-        <p class="hero-tagline">ML Engineer at Nirvana. MS CS from UCLA. Ex-IBM. Co-founder of <a href="https://dynacloud.io/">Dynacloud</a>.</p>
+        <p class="hero-tagline">ML Engineer at Nirvana. MS CS from UCLA. Ex-IBM. Co-founder of Dynacloud.</p>
         <p class="hero-bio">
             I build intelligent systems across the full ML stack — from classical models and
             model training to LLMs, agentic workflows, and production AI systems.


### PR DESCRIPTION
## Summary
Removed the hyperlink from the Dynacloud co-founder mention in the hero section tagline on the homepage.

## Changes
- Removed `<a href="https://dynacloud.io/">Dynacloud</a>` hyperlink element
- Replaced with plain text "Dynacloud" to simplify the tagline

## Details
This change simplifies the hero tagline by removing the external link while keeping the Dynacloud mention. The text now reads "Co-founder of Dynacloud." instead of "Co-founder of <a href="https://dynacloud.io/">Dynacloud</a>."

https://claude.ai/code/session_01CcnoUgWXzL3eBJKndCE57z